### PR TITLE
Bump to 3.0.1 and trim jar to only web-applicable 'iconfont'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>3.0.0</upstream.version>
+        <upstream.version>3.0.1</upstream.version>
         <upstream.url>https://github.com/google/material-design-icons/archive/${upstream.version}.zip</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destDir>
         <requirejs>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,11 @@
                                 <echo message="download archive" />
                                 <get src="${upstream.url}" dest="${project.build.directory}/${project.artifactId}.zip" />
                                 <echo message="unzip archive" />
-                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}" />
+                                <unzip src="${project.build.directory}/${project.artifactId}.zip" dest="${project.build.directory}">
+                                  <patternset>
+                                    <include name="${project.artifactId}-${upstream.version}/iconfont/**" />
+                                  </patternset>
+                                </unzip>
                                 <echo message="moving resources" />
                                 <move todir="${destDir}">
                                     <fileset dir="${project.build.directory}/${project.artifactId}-${upstream.version}" />


### PR DESCRIPTION
This concept was proposed in https://github.com/webjars/webjars/issues/1208#issuecomment-249173483.

With the inclusion of only 'iconfont', the resulting jar is reduced from 66MB to 317KB
![image](https://cloud.githubusercontent.com/assets/988985/18816618/1676dbc8-8313-11e6-95ea-3e1fbbb9bc2b.png)

The resulting jar has been confirmed to be usable with the following `link`:

```
<link rel="stylesheet" href="webjars/material-design-icons/3.0.1-SNAPSHOT/iconfont/material-icons.css">
```
